### PR TITLE
update Twitter Video Async upload method for large video file (<= 512MB)

### DIFF
--- a/SocialVideoHelper.h
+++ b/SocialVideoHelper.h
@@ -1,7 +1,10 @@
 //
 //  SocialVideoHelper.h
 //
-//  Created by ryu-ushin on 6/5/15.
+//  Originally Created by ryu-ushin on 6/5/15.
+//  Updated async Twitter upload methods by LongMA and YuSong on 29/1/17.
+//  Now you should able to upload large video to Twitter (no more than 512MB)
+//  According to https://dev.twitter.com/rest/media/uploading-media
 //  Copyright (c) 2015 ryu-ushin. All rights reserved.
 //
 

--- a/SocialVideoHelper.m
+++ b/SocialVideoHelper.m
@@ -192,7 +192,7 @@
         [requests addObject:postRequest];
     }
 
-    __block NSError *theError = nil;
+//    __block NSError *theError = nil;
 //    dispatch_queue_t chunksRequestQueue = dispatch_queue_create("chunksRequestQueue", DISPATCH_QUEUE_SERIAL);
 
     NSOperationQueue *operationQueue = [[NSOperationQueue alloc] init];
@@ -205,7 +205,7 @@
                 NSLog(@"Twitter Stage2 - %d HTTP Response: %li, %@", (i+1),(long)[urlResponse statusCode], [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding]);
                 if (error) {
                     NSLog(@"Twitter Error stage 2 - %d, error - %@", (i+1), error);
-                    theError = error;
+//                    theError = error;
                     [SocialVideoHelper uploadError:error withCompletion:completion];
                     return;
                 } else {
@@ -222,9 +222,9 @@
 //            dispatch_group_wait(requestGroup, DISPATCH_TIME_FOREVER);
         }
         
-        if (theError) {
-            [SocialVideoHelper uploadError:theError withCompletion:completion];
-        } else {
+//        if (theError) {
+//            [SocialVideoHelper uploadError:theError withCompletion:completion];
+//        } else {
             SLRequest *postRequest = requests.lastObject;
             [postRequest performRequestWithHandler:^(NSData *responseData, NSHTTPURLResponse *urlResponse, NSError *error) {
                 NSLog(@"Twitter Stage2 - final, HTTP Response: %li, %@",(long)[urlResponse statusCode], [[NSString alloc] initWithData:responseData encoding:NSUTF8StringEncoding]);
@@ -239,7 +239,7 @@
                     [SocialVideoHelper tweetVideoStage3:videoData mediaID:mediaID comment:comment account:account withCompletion:completion];
                 }
             }];
-        }
+//        }
     }];
 }
 
@@ -326,9 +326,8 @@
     NSURL *twitterPostURL = [[NSURL alloc] initWithString:@"https://api.twitter.com/1.1/statuses/update.json"];
     
     if (comment == nil) {
-    // try to not prefill the post status text for user
-//        comment = [NSString stringWithFormat:@"#SocialVideoHelper# https://github.com/liu044100/SocialVideoHelper"];
-        comment = [NSString stringWithFormat:@"  "];
+        comment = [NSString stringWithFormat:@"#SocialVideoHelper# https://github.com/liu044100/SocialVideoHelper"];
+//        comment = [NSString stringWithFormat:@"  "];
 
     }
     


### PR DESCRIPTION
Updated Async Twitter upload methods by LongMA and YuSong on 29/1/17.
Now you should able to upload large video to Twitter (no more than 512MB, according to https://dev.twitter.com/rest/media/uploading-media)

We have fully tested the code. 

Thanks a lot

